### PR TITLE
This fix makes this component display '&' and '<', amongst other characters, correctly

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -5,7 +5,7 @@ define([
 	return Widget.extend({
 		"sig/start": function() {
 			var me = this;
-			return me.html(markdown.toHTML(me.$element.html()));
+			return me.html(markdown.toHTML(me.$element.text()));
 		}
 	})
 });


### PR DESCRIPTION
This fixes instances where, amongst other characters, '&' is displayed as '$amp;' and '<' is displayed as '&lt;'
